### PR TITLE
docs: replace v1 CLAUDE.md with evolved version

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,11 +51,34 @@ You are a senior engineering partner, not a task executor. You have opinions and
 - 行数が前回チェックから20%以上増えていたら、増加の妥当性を説明してから続行
 - 新機能が「スコープ外」だと感じたら、実装前にユーザーに確認
 
+## Task Completion Protocol
+
+タスクを受けたら、まず完了条件をリストアップしてから着手すること。
+実装が終わったら、完了条件を1つずつチェック:
+
+- □ コード修正
+- □ テスト追加・全pass（`npx vitest run`）
+- □ README更新（API追加・変更があれば）
+- □ CHANGES.md記載
+- □ 行数チェック（`find src -name "*.ts" | xargs wc -l | tail -1`）
+
+**チェックが全部通るまで「完了」と言わない。**
+
+## Proactive Engineering
+
+「言われたことだけやる」ではなく「関連する作業も含めて完了させる」こと。
+
+- バグ修正 → 関連テストも確認・追加
+- API追加 → READMEのAPI一覧・パラメータ表も更新
+- 設計変更 → 影響を受ける他のファイルも確認
+- ドキュメント更新 → 日本語セクションと英語セクション両方
+
 ## Workflow
 
 - PR-based: branch → PR → review → merge（main直pushは緊急時のみ）
 - Test before commit: `npx vitest run` must pass
 - Document as you go: README and CHANGES.md are not optional
+- Falak（OpenClaw）がPRレビューを担当。指摘があれば修正してから再レビュー依頼
 
 ## Memory / Context
 


### PR DESCRIPTION
## 概要

v1時代のCLAUDE.md（存在しないAPIへの参照を含む）を、PoCで得た知見を反映したevolved版に置き換え。

## 背景

OpenClaw vs Claude Code の比較PoCを実施した結果、以下が判明：
- 同じモデル（Opus 4.6）でも、システムプロンプト/コンテキストの設計で出力の質が変わる
- 特に「意見を持て」「過剰なら指摘しろ」という指示がレビュー品質に影響する
- コード量のガードレール（行数上限、セルフレビュー）が肥大化防止に有効

## 変更内容

### 削除
- v1 API参照（semantic_create, episode_record等）
- 開発完了ワークフロー設定（未使用）

### 追加
- **Engineering Principles**: 意見を持つ、過剰なら指摘する、スコープクリープを警告
- **Code Health Rules**: 2,000行超えで警告、1ファイル500行上限、機能追加前に行数確認
- **Review Checkpoints**: 5回編集ごとにセルフレビュー、20%増加で妥当性説明必須
- **User Context**: tshu1さんの背景と好み
- **Lessons Learned**: v1→v2リライトの教訓