### PR TITLE
feat: memory curation with duplicate detection (v3.1)

### DIFF
--- a/src/curate.ts
+++ b/src/curate.ts
@@ -1,0 +1,156 @@
+// cc-memory v3.1 - Memory curation: KNN-based duplicate detection
+import type { Memory } from "./types.js";
+import type { Storage } from "./storage.js";
+
+const STALE_DAYS = 90;
+
+export interface DuplicateGroup {
+  anchor: Memory;       // keep (oldest in group)
+  duplicates: Memory[]; // removal candidates
+  similarity: number;   // lowest similarity in group
+}
+
+export interface CurationReport {
+  total_memories: number;
+  duplicate_groups: DuplicateGroup[];
+  stale_memories: Memory[];
+  actions_taken: Array<{ action: string; memory_id: string; detail: string }>;
+}
+
+// Union-Find for grouping duplicates
+class UnionFind {
+  private parent: Map<string, string> = new Map();
+
+  find(x: string): string {
+    if (!this.parent.has(x)) this.parent.set(x, x);
+    let root = x;
+    while (this.parent.get(root) !== root) root = this.parent.get(root)!;
+    // Path compression
+    let curr = x;
+    while (curr !== root) {
+      const next = this.parent.get(curr)!;
+      this.parent.set(curr, root);
+      curr = next;
+    }
+    return root;
+  }
+
+  union(a: string, b: string): void {
+    const ra = this.find(a);
+    const rb = this.find(b);
+    if (ra !== rb) this.parent.set(ra, rb);
+  }
+
+  groups(): Map<string, string[]> {
+    const result = new Map<string, string[]>();
+    for (const key of this.parent.keys()) {
+      const root = this.find(key);
+      if (!result.has(root)) result.set(root, []);
+      result.get(root)!.push(key);
+    }
+    return result;
+  }
+}
+
+export function analyzeMemories(
+  storage: Storage,
+  memories: Memory[],
+  threshold: number = 0.85
+): CurationReport {
+  const now = Date.now();
+  const staleMs = STALE_DAYS * 24 * 60 * 60 * 1000;
+
+  // Stale detection
+  const stale_memories = memories.filter(
+    (m) => now - new Date(m.updated_at).getTime() > staleMs
+  );
+
+  // Duplicate detection via KNN
+  const uf = new UnionFind();
+  const similarities = new Map<string, number>(); // "id1:id2" → similarity
+
+  for (const mem of memories) {
+    // Get embedding for this memory, search for neighbors
+    const neighbors = storage.vectorSearchPublic(mem.id, mem.project_id, 5);
+    for (const n of neighbors) {
+      if (n.memory_id === mem.id) continue;
+      const similarity = 1 - n.distance;
+      if (similarity >= threshold) {
+        uf.union(mem.id, n.memory_id);
+        const key = [mem.id, n.memory_id].sort().join(":");
+        const existing = similarities.get(key);
+        if (existing === undefined || similarity < existing) {
+          similarities.set(key, similarity);
+        }
+      }
+    }
+  }
+
+  // Build duplicate groups
+  const memoryMap = new Map(memories.map((m) => [m.id, m]));
+  const groups = uf.groups();
+  const duplicate_groups: DuplicateGroup[] = [];
+
+  for (const [, memberIds] of groups) {
+    if (memberIds.length < 2) continue;
+
+    const members = memberIds
+      .map((id) => memoryMap.get(id))
+      .filter((m): m is Memory => m !== undefined)
+      .sort((a, b) => a.created_at.localeCompare(b.created_at)); // oldest first
+
+    if (members.length < 2) continue;
+
+    // Find minimum similarity within this group
+    let minSim = 1;
+    for (let i = 0; i < members.length; i++) {
+      for (let j = i + 1; j < members.length; j++) {
+        const key = [members[i].id, members[j].id].sort().join(":");
+        const sim = similarities.get(key);
+        if (sim !== undefined && sim < minSim) minSim = sim;
+      }
+    }
+
+    duplicate_groups.push({
+      anchor: members[0],
+      duplicates: members.slice(1),
+      similarity: minSim,
+    });
+  }
+
+  return {
+    total_memories: memories.length,
+    duplicate_groups,
+    stale_memories,
+    actions_taken: [],
+  };
+}
+
+export function executeCuration(
+  storage: Storage,
+  report: CurationReport
+): CurationReport {
+  const actions: CurationReport["actions_taken"] = [];
+
+  for (const group of report.duplicate_groups) {
+    for (const dup of group.duplicates) {
+      storage.deleteMemory(dup.id);
+      actions.push({
+        action: "deleted_duplicate",
+        memory_id: dup.id,
+        detail: `duplicate of ${group.anchor.id} (similarity: ${group.similarity.toFixed(3)})`,
+      });
+    }
+  }
+
+  // Stale memories: report only, do not auto-delete
+  for (const mem of report.stale_memories) {
+    actions.push({
+      action: "flagged_stale",
+      memory_id: mem.id,
+      detail: `last updated: ${mem.updated_at}`,
+    });
+  }
+
+  return { ...report, actions_taken: actions };
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -270,6 +270,21 @@ export class Storage {
     }>;
   }
 
+  // Find neighbors of an existing memory by its stored embedding
+  vectorSearchPublic(
+    memoryId: string,
+    projectId: string,
+    limit: number
+  ): Array<{ memory_id: string; distance: number }> {
+    if (!this.vectorEnabled) return [];
+    // Get stored embedding for this memory
+    const row = this.db
+      .prepare("SELECT embedding FROM vec_memories WHERE memory_id = ?")
+      .get(memoryId) as { embedding: Buffer } | undefined;
+    if (!row) return [];
+    return this.vectorSearch(new Float32Array(row.embedding.buffer.slice(row.embedding.byteOffset, row.embedding.byteOffset + row.embedding.byteLength)), projectId, limit);
+  }
+
   getMemory(id: string): Memory | undefined {
     const row = this.db.prepare("SELECT * FROM memories WHERE id = ?").get(id) as RawMemory | undefined;
     return row ? parseMemoryRow(row) : undefined;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { Storage } from "./storage.js";
 import { checkStorePermission, checkReadPermission, getAgentRole, AuthError } from "./auth.js";
 import { embed, DIMENSIONS } from "./embeddings.js";
+import { analyzeMemories, executeCuration } from "./curate.js";
 
 const DEFAULT_PROJECT = "default";
 
@@ -53,6 +54,14 @@ export const schemas = {
   }),
   agent_list: z.object({
     project_id: z.string(),
+  }),
+  memory_curate: z.object({
+    caller_id: z.string(),
+    scope: z.enum(["shared", "personal"]),
+    agent_id: z.string().optional(),
+    project_id: z.string().optional(),
+    dry_run: z.boolean().optional().default(true),
+    similarity_threshold: z.number().min(0).max(1).optional().default(0.85),
   }),
 };
 
@@ -171,6 +180,22 @@ export const toolDefinitions = [
         project_id: { type: "string", description: "Project ID" },
       },
       required: ["project_id"],
+    },
+  },
+  {
+    name: "memory_curate",
+    description: "Analyze and deduplicate memories. dry_run=true reports only, false deletes duplicates. Requires vector search to be enabled.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        caller_id: { type: "string", description: "Caller agent ID for permission checks" },
+        scope: { type: "string", enum: ["shared", "personal"], description: "Scope to curate" },
+        agent_id: { type: "string", description: "Target agent ID (personal scope, manager only)" },
+        project_id: { type: "string", description: "Project ID" },
+        dry_run: { type: "boolean", description: "true=report only (default), false=delete duplicates" },
+        similarity_threshold: { type: "number", description: "Cosine similarity threshold (default: 0.85)" },
+      },
+      required: ["caller_id", "scope"],
     },
   },
 ];
@@ -349,6 +374,63 @@ export function createToolHandler(storage: Storage) {
           const input = schemas.agent_list.parse(args);
           const agents = storage.listAgents(input.project_id);
           return JSON.stringify({ ok: true, count: agents.length, agents });
+        }
+
+        case "memory_curate": {
+          const input = schemas.memory_curate.parse(args);
+          const projectId = input.project_id ?? DEFAULT_PROJECT;
+
+          // Require vector search
+          if (!storage.vectorEnabled) {
+            return JSON.stringify({ ok: false, error: "Vector search is required for curation. Install sqlite-vec." });
+          }
+
+          // RBAC: shared → manager only, personal → own or manager
+          const role = getAgentRole(storage, projectId, input.caller_id);
+          if (!role) {
+            throw new AuthError(`Agent "${input.caller_id}" is not registered in project "${projectId}"`);
+          }
+          if (input.scope === "shared" && role !== "manager") {
+            throw new AuthError("Only managers can curate shared scope");
+          }
+          const targetAgent = input.scope === "personal"
+            ? (input.agent_id ?? input.caller_id)
+            : undefined;
+          if (input.scope === "personal" && targetAgent !== input.caller_id && role !== "manager") {
+            throw new AuthError("Workers can only curate their own personal memories");
+          }
+
+          // Get target memories
+          const memories = storage.listMemories(input.scope, projectId, targetAgent);
+          const report = analyzeMemories(storage, memories, input.similarity_threshold);
+
+          if (!input.dry_run) {
+            const executed = executeCuration(storage, report);
+            return JSON.stringify({
+              ok: true,
+              dry_run: false,
+              total_memories: executed.total_memories,
+              duplicate_groups: executed.duplicate_groups.length,
+              duplicates_deleted: executed.actions_taken.filter((a) => a.action === "deleted_duplicate").length,
+              stale_memories: executed.stale_memories.length,
+              actions: executed.actions_taken,
+            });
+          }
+
+          // Dry run: report only
+          return JSON.stringify({
+            ok: true,
+            dry_run: true,
+            total_memories: report.total_memories,
+            duplicate_groups: report.duplicate_groups.length,
+            duplicates_found: report.duplicate_groups.reduce((n, g) => n + g.duplicates.length, 0),
+            stale_memories: report.stale_memories.length,
+            details: report.duplicate_groups.map((g) => ({
+              keep: { id: g.anchor.id, preview: g.anchor.content.slice(0, 60) },
+              remove: g.duplicates.map((d) => ({ id: d.id, preview: d.content.slice(0, 60) })),
+              similarity: g.similarity,
+            })),
+          });
         }
 
         default:

--- a/tests/curate.test.ts
+++ b/tests/curate.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { Storage } from "../src/storage.js";
+import { createToolHandler, schemas } from "../src/tools.js";
+import { analyzeMemories, executeCuration } from "../src/curate.js";
+import { unlinkSync } from "node:fs";
+
+const TEST_DB = "test-curate.db";
+
+describe("Curation", () => {
+  let storage: Storage;
+
+  beforeEach(() => {
+    storage = new Storage(TEST_DB);
+    storage.createProject("p1", "test");
+    storage.registerAgent("p1", "mgr", "manager");
+    storage.registerAgent("p1", "wkr", "worker");
+  });
+
+  afterEach(() => {
+    storage.close();
+    try { unlinkSync(TEST_DB); } catch {}
+    try { unlinkSync(TEST_DB + "-wal"); } catch {}
+    try { unlinkSync(TEST_DB + "-shm"); } catch {}
+  });
+
+  function storeWithEmbedding(content: string, scope: "shared" | "personal", agentId: string | null, embedding: Float32Array) {
+    const mem = storage.storeMemory("p1", scope, agentId, content, null, agentId ?? "mgr");
+    storage.storeEmbedding(mem.id, "p1", embedding);
+    return mem;
+  }
+
+  it("detects duplicates (similar embeddings)", () => {
+    // Two very similar embeddings
+    const emb1 = new Float32Array(384).fill(0);
+    emb1[0] = 1.0;
+    const emb2 = new Float32Array(384).fill(0);
+    emb2[0] = 0.99;
+    emb2[1] = 0.01;
+    // One different embedding
+    const emb3 = new Float32Array(384).fill(0);
+    emb3[1] = 1.0;
+
+    storeWithEmbedding("monitoring config for prometheus", "shared", null, emb1);
+    storeWithEmbedding("monitoring configuration prometheus", "shared", null, emb2);
+    storeWithEmbedding("database backup schedule", "shared", null, emb3);
+
+    const memories = storage.listMemories("shared", "p1");
+    const report = analyzeMemories(storage, memories, 0.85);
+
+    expect(report.total_memories).toBe(3);
+    expect(report.duplicate_groups.length).toBe(1);
+    expect(report.duplicate_groups[0].duplicates.length).toBe(1);
+  });
+
+  it("does not flag dissimilar memories as duplicates", () => {
+    const emb1 = new Float32Array(384).fill(0);
+    emb1[0] = 1.0;
+    const emb2 = new Float32Array(384).fill(0);
+    emb2[1] = 1.0;
+
+    storeWithEmbedding("monitoring config", "shared", null, emb1);
+    storeWithEmbedding("database backup", "shared", null, emb2);
+
+    const memories = storage.listMemories("shared", "p1");
+    const report = analyzeMemories(storage, memories, 0.85);
+
+    expect(report.duplicate_groups.length).toBe(0);
+  });
+
+  it("keeps oldest memory as anchor", () => {
+    const emb = new Float32Array(384).fill(0);
+    emb[0] = 1.0;
+    const embClose = new Float32Array(384).fill(0);
+    embClose[0] = 0.999;
+
+    const older = storeWithEmbedding("first version", "shared", null, emb);
+    storeWithEmbedding("second version (dupe)", "shared", null, embClose);
+
+    const memories = storage.listMemories("shared", "p1");
+    const report = analyzeMemories(storage, memories, 0.85);
+
+    expect(report.duplicate_groups.length).toBe(1);
+    expect(report.duplicate_groups[0].anchor.id).toBe(older.id);
+  });
+
+  it("executeCuration deletes duplicates", () => {
+    const emb = new Float32Array(384).fill(0);
+    emb[0] = 1.0;
+    const embClose = new Float32Array(384).fill(0);
+    embClose[0] = 0.999;
+
+    storeWithEmbedding("original", "shared", null, emb);
+    const dupe = storeWithEmbedding("duplicate of original", "shared", null, embClose);
+
+    const memories = storage.listMemories("shared", "p1");
+    const report = analyzeMemories(storage, memories, 0.85);
+    const result = executeCuration(storage, report);
+
+    expect(result.actions_taken.some((a) => a.action === "deleted_duplicate" && a.memory_id === dupe.id)).toBe(true);
+
+    // Verify actually deleted
+    expect(storage.getMemory(dupe.id)).toBeUndefined();
+  });
+
+  it("detects stale memories (>90 days old)", () => {
+    const emb = new Float32Array(384).fill(0);
+    emb[0] = 1.0;
+
+    // Manually insert a stale memory with old updated_at
+    const mem = storage.storeMemory("p1", "shared", null, "ancient config", null, "mgr");
+    storage.storeEmbedding(mem.id, "p1", emb);
+
+    // Hack updated_at to 100 days ago
+    const oldDate = new Date(Date.now() - 100 * 24 * 60 * 60 * 1000).toISOString();
+    (storage as any).db.prepare("UPDATE memories SET updated_at = ? WHERE id = ?").run(oldDate, mem.id);
+
+    const memories = storage.listMemories("shared", "p1");
+    // Re-fetch to get updated timestamp
+    const freshMemories = memories.map((m) => storage.getMemory(m.id)!);
+    const report = analyzeMemories(storage, freshMemories, 0.85);
+
+    expect(report.stale_memories.length).toBe(1);
+    expect(report.stale_memories[0].id).toBe(mem.id);
+  });
+
+  // Tool handler integration tests
+  describe("memory_curate tool", () => {
+    let handle: (name: string, args: Record<string, unknown>) => Promise<string>;
+    const parse = async (name: string, args: Record<string, unknown>) =>
+      JSON.parse(await handle(name, args));
+
+    beforeEach(() => {
+      handle = createToolHandler(storage);
+    });
+
+    it("dry_run returns report without deleting", async () => {
+      const emb = new Float32Array(384).fill(0);
+      emb[0] = 1.0;
+      const embClose = new Float32Array(384).fill(0);
+      embClose[0] = 0.999;
+
+      storeWithEmbedding("config A", "shared", null, emb);
+      storeWithEmbedding("config A copy", "shared", null, embClose);
+
+      const result = await parse("memory_curate", {
+        caller_id: "mgr",
+        scope: "shared",
+        project_id: "p1",
+        dry_run: true,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.dry_run).toBe(true);
+      expect(result.duplicates_found).toBeGreaterThan(0);
+
+      // Verify nothing was deleted
+      const all = storage.listMemories("shared", "p1");
+      expect(all.length).toBe(2);
+    });
+
+    it("dry_run=false deletes duplicates", async () => {
+      const emb = new Float32Array(384).fill(0);
+      emb[0] = 1.0;
+      const embClose = new Float32Array(384).fill(0);
+      embClose[0] = 0.999;
+
+      storeWithEmbedding("original", "shared", null, emb);
+      storeWithEmbedding("near-duplicate", "shared", null, embClose);
+
+      const result = await parse("memory_curate", {
+        caller_id: "mgr",
+        scope: "shared",
+        project_id: "p1",
+        dry_run: false,
+      });
+
+      expect(result.ok).toBe(true);
+      expect(result.dry_run).toBe(false);
+      expect(result.duplicates_deleted).toBe(1);
+
+      const remaining = storage.listMemories("shared", "p1");
+      expect(remaining.length).toBe(1);
+    });
+
+    it("blocks worker from curating shared scope", async () => {
+      const result = await parse("memory_curate", {
+        caller_id: "wkr",
+        scope: "shared",
+        project_id: "p1",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("manager");
+    });
+
+    it("allows worker to curate own personal scope", async () => {
+      const emb = new Float32Array(384).fill(0);
+      emb[0] = 1.0;
+      storeWithEmbedding("my note", "personal", "wkr", emb);
+
+      const result = await parse("memory_curate", {
+        caller_id: "wkr",
+        scope: "personal",
+        project_id: "p1",
+      });
+
+      expect(result.ok).toBe(true);
+    });
+
+    it("blocks worker from curating another agent's personal scope", async () => {
+      storage.registerAgent("p1", "other", "worker");
+
+      const result = await parse("memory_curate", {
+        caller_id: "wkr",
+        scope: "personal",
+        agent_id: "other",
+        project_id: "p1",
+      });
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toContain("own personal");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **KNN ベース重複検出**: 各メモリの近傍を `vectorSearch(limit=5)` で取得し、Union-Find でグループ化。O(n×k) で O(n²) ペアワイズより効率的
- **`memory_curate` MCP ツール**: dry_run=true（デフォルト）でレポートのみ、false で重複削除実行
- **RBAC 準拠**: shared は manager のみ、personal は自分の記憶のみ（manager は任意エージェント指定可）
- **Stale 検出**: 90日以上未更新の記憶をフラグ（自動削除はしない）

## Changes

| ファイル | 内容 |
|---|---|
| `src/curate.ts` (NEW, 156行) | analyzeMemories + executeCuration + Union-Find |
| `src/storage.ts` (+15行) | `vectorSearchPublic()` — 既存埋め込みからの近傍検索 |
| `src/tools.ts` (+82行) | `memory_curate` schema + ツール定義 + ハンドラ |
| `tests/curate.test.ts` (NEW) | 10テスト |

## Base branch

`v3.0/semantic-search` (#6) の上に乗ってるので、そちらが先にマージされる必要あり。

## Test plan

- [x] 重複検出: 類似embedding → グループ化確認
- [x] 非類似: 異なるembedding → グループ化されない
- [x] Anchor選択: 最古のメモリが保持される
- [x] 実行: dry_run=false で実際に削除
- [x] Stale検出: 90日超の記憶がフラグされる
- [x] RBAC: worker→shared拒否、worker→他人personal拒否、worker→自分personalOK
- [x] dry_run=trueでレポートのみ（削除なし）

## Code health

src/ 1,330行（8ファイル）— 2,000行上限以内

🤖 Generated with [Claude Code](https://claude.com/claude-code)