### PR TITLE
fix: digest JSONL parsing — match Claude Code actual format

### DIFF
--- a/templates/skills/digest/SKILL.md
+++ b/templates/skills/digest/SKILL.md
@@ -53,7 +53,8 @@ memory_list({
 ```bash
 # $ARGUMENTS が空なら DAYS=3、数値なら指定値を使う
 DAYS="${ARGUMENTS:-3}"
-find ~/.claude/projects -name "*.jsonl" -mtime -${DAYS} -type f 2>/dev/null
+# subagents/ 配下を除外してメインセッションのみ列挙
+find ~/.claude/projects -name "*.jsonl" -not -path "*/subagents/*" -mtime -${DAYS} -type f 2>/dev/null
 ```
 
 各ファイルのベース名（拡張子なし）がセッションIDとなる。
@@ -84,13 +85,13 @@ with open(sys.argv[1], "r") as f:
         except json.JSONDecodeError:
             continue
 
-        if record.get("type") != "message":
+        # Claude Code JSONL: type が "user" / "assistant" でロールを直接示す
+        rec_type = record.get("type", "")
+        if rec_type not in ("user", "assistant"):
             continue
+        role = rec_type
 
         msg = record.get("message", {})
-        role = msg.get("role")
-        if role not in ("user", "assistant"):
-            continue
 
         # assistant のストリーミング重複を message.id でデデュプ
         msg_id = msg.get("id")


### PR DESCRIPTION
## Summary

dogfooding で発見したバグ2件を修正:

- Claude Code の JSONL は `type: "message"` + `message.role` ではなく、`type: "user"` / `type: "assistant"` で直接ロールを示す → 抽出スクリプトが全メッセージをスキップして空出力になっていた
- `find` が `subagents/` 配下の JSONL も拾っていた → メインセッションのみに絞る

## Test plan

- [x] 615KB セッション → 13KB / 36メッセージ抽出を確認
- [x] 2.5MB セッション → 79KB / 112メッセージ抽出を確認
- [x] subagents/ のファイルが除外されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)