### PR TITLE
fix: update run.sh entrypoint to dist/server.js

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-exec node "$(dirname "$0")/dist/index.js" "$@"
+exec node "$(dirname "$0")/dist/server.js" "$@"


### PR DESCRIPTION
## Summary
- `run.sh` のエントリポイントが `dist/index.js` のままだった（v3 で `dist/server.js` にリネーム済み）
- MCP サーバーのアップグレード後に接続失敗する原因

## Test plan
- [x] `run.sh` で MCP サーバーが正常起動することを確認済み（手動テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)