### PR TITLE
feat: session_recall に project_path フィルタ追加

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- `session_recall` に `project_path` フィルタを追加 — 特定プロジェクトのセッションのみに絞り込み検索可能
+
 ## v3.2.0
 
 ### Short-term Memory: `session_recall` ツール

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ cc-memory setup
 | `caller_id` | `string` | ✅ | 呼び出し元エージェント ID |
 | `days` | `number` | - | 対象日数（1-30、デフォルト: 7） |
 | `project_id` | `string` | - | プロジェクト ID（認可チェック用。セッションの検索絞り込みには使用されません） |
+| `project_path` | `string` | - | プロジェクトパスでフィルタ（例: `-home-user-myproject`）。省略時は全プロジェクト対象 |
 | `limit` | `number` | - | 最大件数（1-50、デフォルト: 10） |
 | `embedding` | `boolean` | - | `true` でハイブリッド検索 |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,6 @@
 
 ## Now (next up)
 - [ ] session_recall のパフォーマンス最適化 — 大量セッション時のインデックス速度改善
-- [ ] session_recall の project_path フィルタ — 特定プロジェクトのセッションのみ検索
 
 ## Next
 - [ ] メモリの重要度スコアリング — recall 結果のランキング改善

--- a/src/session.ts
+++ b/src/session.ts
@@ -120,11 +120,11 @@ export async function indexNewSessions(
 export async function searchChunks(
   storage: Storage,
   query: string,
-  opts: { days?: number; limit?: number; queryEmbedding?: Float32Array }
+  opts: { days?: number; limit?: number; queryEmbedding?: Float32Array; projectPath?: string }
 ): Promise<SessionChunk[]> {
-  const { limit = 10, queryEmbedding } = opts;
+  const { limit = 10, queryEmbedding, projectPath } = opts;
 
-  return storage.searchSessionChunks(queryEmbedding, query, limit);
+  return storage.searchSessionChunks(queryEmbedding, query, limit, projectPath);
 }
 
 // --- Internal helpers ---

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -453,10 +453,11 @@ export class Storage {
   searchSessionChunks(
     queryEmbedding: Float32Array | undefined,
     query: string,
-    limit: number
+    limit: number,
+    projectPath?: string
   ): SessionChunk[] {
     if (!this.vectorEnabled || !queryEmbedding || queryEmbedding.length === 0) {
-      return this.keywordSearchChunks(query, limit);
+      return this.keywordSearchChunks(query, limit, projectPath);
     }
 
     const buf = Buffer.from(queryEmbedding.buffer, queryEmbedding.byteOffset, queryEmbedding.byteLength);
@@ -465,7 +466,7 @@ export class Storage {
       .all(buf, limit * 3) as Array<{ chunk_id: string; distance: number }>;
     const vecMap = new Map(vecResults.map((r) => [r.chunk_id, r.distance]));
 
-    const keywordResults = this.keywordSearchChunks(query, limit * 3);
+    const keywordResults = this.keywordSearchChunks(query, limit * 3, projectPath);
     const keywordMap = new Map(keywordResults.map((c) => [c.id, c]));
 
     // Merge all candidate IDs
@@ -480,6 +481,9 @@ export class Storage {
         if (!row) continue;
         chunk = row;
       }
+
+      // Apply project_path filter for vec-only results
+      if (projectPath && chunk.project_path !== projectPath) continue;
 
       const vecDistance = vecMap.get(id);
       const vecScore = vecDistance !== undefined ? (1 - vecDistance) : 0;
@@ -499,12 +503,17 @@ export class Storage {
       .map((s) => s.chunk);
   }
 
-  private keywordSearchChunks(query: string, limit: number): SessionChunk[] {
+  private keywordSearchChunks(query: string, limit: number, projectPath?: string): SessionChunk[] {
     const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
     if (terms.length === 0) return [];
 
     let sql = "SELECT * FROM session_chunks WHERE 1=1";
     const params: unknown[] = [];
+
+    if (projectPath) {
+      sql += " AND project_path = ?";
+      params.push(projectPath);
+    }
 
     const likeClauses = terms.map(() => "content LIKE ? ESCAPE '\\'");
     sql += " AND (" + likeClauses.join(" OR ") + ")";

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -76,6 +76,7 @@ export const schemas = {
     caller_id: z.string(),
     days: z.number().int().min(1).max(30).optional(),
     project_id: z.string().optional(), // used for auth check only
+    project_path: z.string().optional(), // filter by project path (e.g. "-home-user-myproject")
     limit: z.number().int().min(1).max(50).optional(),
     embedding: embeddingSchema,
   }),
@@ -259,6 +260,7 @@ export const toolDefinitions = [
         caller_id: { type: "string", description: "Caller agent ID (must be registered in project)" },
         days: { type: "number", description: "Number of days to search (default: 7, max: 30)" },
         project_id: { type: "string", description: "Project ID for auth check (default: 'default')" },
+        project_path: { type: "string", description: "Filter by project path (e.g. '-home-user-myproject'). Omit to search all projects." },
         limit: { type: "number", description: "Max results (default: 10, max: 50)" },
         embedding: { oneOf: [{ type: "boolean", const: true }, { type: "array", items: { type: "number" } }], description: "true = auto-generate query embedding for hybrid search" },
       },
@@ -495,6 +497,7 @@ export function createToolHandler(storage: Storage) {
             days,
             limit,
             queryEmbedding,
+            projectPath: input.project_path,
           });
 
           return JSON.stringify({

--- a/tests/session.test.ts
+++ b/tests/session.test.ts
@@ -325,4 +325,26 @@ describe("Storage session_chunks", () => {
     expect(results.length).toBeGreaterThanOrEqual(1);
     expect(results[0].content).toContain("TypeScript");
   });
+
+  it("filters by project_path", () => {
+    storage.storeSessionChunk({
+      id: "a:0", session_id: "a", project_path: "-home-user-project-alpha",
+      chunk_index: 0, content: "Alpha project setup with Rust",
+      timestamp: new Date().toISOString(), indexed_at: new Date().toISOString(),
+    });
+    storage.storeSessionChunk({
+      id: "b:0", session_id: "b", project_path: "-home-user-project-beta",
+      chunk_index: 0, content: "Beta project setup with Rust",
+      timestamp: new Date().toISOString(), indexed_at: new Date().toISOString(),
+    });
+
+    // With filter: only alpha
+    const alpha = storage.searchSessionChunks(new Float32Array(0), "Rust", 10, "-home-user-project-alpha");
+    expect(alpha.length).toBe(1);
+    expect(alpha[0].project_path).toBe("-home-user-project-alpha");
+
+    // Without filter: both
+    const all = storage.searchSessionChunks(new Float32Array(0), "Rust", 10);
+    expect(all.length).toBe(2);
+  });
 });


### PR DESCRIPTION
## Summary
- `session_recall` に `project_path` パラメータを追加
- 特定プロジェクトのセッションのみに絞り込んで検索可能
- vector 検索結果にも project_path フィルタを適用（keyword 側は SQL WHERE、vector 側はポストフィルタ）

## Changes
- `src/tools.ts` — schema + inputSchema に `project_path` 追加、handler で searchChunks に渡す
- `src/session.ts` — searchChunks の opts に `projectPath` 追加
- `src/storage.ts` — searchSessionChunks, keywordSearchChunks に project_path WHERE 条件追加
- `tests/session.test.ts` — project_path フィルタのテスト追加
- `README.md` — パラメータ表に project_path 追加
- `CHANGES.md`, `ROADMAP.md` — 更新

## Test plan
- [x] 82 tests pass (`npx vitest run`)
- [x] project_path フィルタ: 指定時は該当プロジェクトのみ返る
- [x] project_path 省略時は全プロジェクト検索（既存動作維持）
- [x] src/ 1,888行（上限 2,000行内）

🤖 Generated with [Claude Code](https://claude.com/claude-code)