### PR TITLE
docs: switch MCP config to npx for auto-updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,31 @@ Personal Scope（個人層）← 本人のみ読み書き
 
 ## インストール & セットアップ
 
-```bash
-# グローバルインストール
-npm install -g cc-memory
-
-# データベース初期化
-cc-memory setup
-```
-
 ### Claude Code で使う
 
 `~/.claude/settings.json` に以下を追加:
+
+```json
+{
+  "mcpServers": {
+    "cc-memory": {
+      "command": "npx",
+      "args": ["-y", "cc-memory", "serve"]
+    }
+  }
+}
+```
+
+グローバルインストール不要。npx が自動でパッケージを取得・キャッシュし、新バージョンがあれば自動更新されます。
+
+> 初回起動時に DB ファイルが自動作成されます。デフォルトパスは `./cc-memory.db`（環境変数 `CC_MEMORY_DB` で変更可）。
+
+<details>
+<summary>グローバルインストールで使う場合</summary>
+
+```bash
+npm install -g cc-memory
+```
 
 ```json
 {
@@ -77,7 +91,9 @@ cc-memory setup
 }
 ```
 
-> `cc-memory setup` を実行すると DB ファイルが作成されます。デフォルトパスは `./cc-memory.db`（環境変数 `CC_MEMORY_DB` で変更可）。
+更新は `npm update -g cc-memory` で手動実行。
+
+</details>
 
 ---
 
@@ -328,8 +344,8 @@ cc-memory migrate-embeddings  # 既存メモリにベクトル埋め込みを一
 {
   "mcpServers": {
     "cc-memory": {
-      "command": "cc-memory",
-      "args": ["serve"],
+      "command": "npx",
+      "args": ["-y", "cc-memory", "serve"],
       "env": {
         "CC_MEMORY_DEFAULT_AGENT": "my-agent"
       }
@@ -470,19 +486,14 @@ A memory server for multi-agent development that separates **shared knowledge** 
 
 ### Quick Start
 
-```bash
-npm install -g cc-memory
-cc-memory setup
-```
-
 Add to `~/.claude/settings.json`:
 
 ```json
 {
   "mcpServers": {
     "cc-memory": {
-      "command": "cc-memory",
-      "args": ["serve"]
+      "command": "npx",
+      "args": ["-y", "cc-memory", "serve"]
     }
   }
 }

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -4,9 +4,7 @@
 
 ## TL;DR — 最短3コマンド
 
-```bash
-npm install -g cc-memory && cc-memory setup
-```
+MCP 設定を追加したら、すぐに使えます（インストール不要）:
 
 Claude Code で:
 ```
@@ -18,24 +16,7 @@ memory_recall を実行: scope="shared", query="Hello", caller_id="me", project_
 
 ---
 
-## Step 1: インストール（1分）
-
-```bash
-npm install -g cc-memory
-cc-memory setup
-```
-
-期待される出力:
-```
-Setting up cc-memory v3...
-  sqlite-vec: enabled ✅
-Database created at: /path/to/cc-memory.db
-Setup complete.
-```
-
-> sqlite-vec が `not available ⚠️` でも動作します（キーワード検索のみになります）。
-
-## Step 2: Claude Code に接続（1分）
+## Step 1: Claude Code に接続（1分）
 
 `~/.claude/settings.json` に追加:
 
@@ -43,12 +24,14 @@ Setup complete.
 {
   "mcpServers": {
     "cc-memory": {
-      "command": "cc-memory",
-      "args": ["serve"]
+      "command": "npx",
+      "args": ["-y", "cc-memory", "serve"]
     }
   }
 }
 ```
+
+> グローバルインストール不要。npx が自動でダウンロード・キャッシュします。初回起動時に DB も自動作成されます。
 
 Claude Code を再起動して、MCP ツールが認識されていることを確認:
 
@@ -56,7 +39,7 @@ Claude Code を再起動して、MCP ツールが認識されていることを�
 > cc-memory の memory_store ツールを使えますか？
 ```
 
-## Step 3: プロジェクト & エージェント登録（1分）
+## Step 2: プロジェクト & エージェント登録（1分）
 
 Claude Code 内で以下を依頼:
 
@@ -76,7 +59,7 @@ Claude Code 内で以下を依頼:
 { "success": true, "agent_id": "lead", "role": "manager", "project_id": "my-app" }
 ```
 
-## Step 4: メモリを保存（shared + personal）（1分）
+## Step 3: メモリを保存（shared + personal）（1分）
 
 ### Shared メモリ（チーム共有）
 
@@ -105,7 +88,7 @@ memory_store を実行:
   project_id: "my-app"
 ```
 
-## Step 5: メモリを検索（1分）
+## Step 4: メモリを検索（1分）
 
 ### memory_recall
 


### PR DESCRIPTION
## Summary
- MCP 設定のデフォルトを `npx -y cc-memory serve` に変更
- グローバルインストール方式は折りたたみセクションで残す
- QUICKSTART からインストール手順を削除し、MCP 設定から開始に簡素化
- 全 MCP 設定例を一貫して npx に統一

## Why
- グローバルインストール不要で導入障壁が下がる
- `npm publish` すれば利用者側が自動的に最新版を使える
- 運用の手間（`npm update -g`）がなくなる

## Test plan
- [x] ドキュメント変更のみ（コード変更なし）
- [x] MCP 設定例の JSON 構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)