### PR TITLE
ops: add weekly KPI tracking template

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- MCP 設定のデフォルトを `npx -y cc-memory serve` に変更（PR #28、docs のみ、次リリースに同梱）
+- KPI 週次テンプレート追加（`docs/KPI-WEEKLY-TEMPLATE.md`）
+
 ## v3.3.0
 
 - `session_recall` に `project_path` フィルタを追加 — 特定プロジェクトのセッションのみに絞り込み検索可能

--- a/docs/KPI-WEEKLY-TEMPLATE.md
+++ b/docs/KPI-WEEKLY-TEMPLATE.md
@@ -1,0 +1,115 @@
+# Weekly KPI Tracking
+
+> cc-memory v3.3.0 — 1-week adoption observation
+
+## Observation Period
+
+- Start: 2026-03-17
+- End: 2026-03-23
+- Version: v3.3.0
+
+## Decision Rubric
+
+| Outcome | Criteria |
+|---------|----------|
+| **Continue** | useful hit rate >= 50% かつ practical wins >= 3 |
+| **Improve** | useful hit rate 30-50% |
+| **Pivot/Stop** | useful hit rate < 30% |
+
+## Daily Log
+
+### Day 1 (2026-03-17)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Active users | 1 | tshu1 (developer) |
+| recall count | - | |
+| useful hit count | - | |
+| setup success | 1 | v3.3.0 publish + npx config |
+| setup fail | 0 | |
+| incidents helped | 0 | |
+
+### Day 2 (2026-03-18)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Active users | | |
+| recall count | | |
+| useful hit count | | |
+| setup success | | |
+| setup fail | | |
+| incidents helped | | |
+
+### Day 3 (2026-03-19)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Active users | | |
+| recall count | | |
+| useful hit count | | |
+| setup success | | |
+| setup fail | | |
+| incidents helped | | |
+
+### Day 4 (2026-03-20)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Active users | | |
+| recall count | | |
+| useful hit count | | |
+| setup success | | |
+| setup fail | | |
+| incidents helped | | |
+
+### Day 5 (2026-03-21)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Active users | | |
+| recall count | | |
+| useful hit count | | |
+| setup success | | |
+| setup fail | | |
+| incidents helped | | |
+
+### Day 6 (2026-03-22)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Active users | | |
+| recall count | | |
+| useful hit count | | |
+| setup success | | |
+| setup fail | | |
+| incidents helped | | |
+
+### Day 7 (2026-03-23)
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Active users | | |
+| recall count | | |
+| useful hit count | | |
+| setup success | | |
+| setup fail | | |
+| incidents helped | | |
+
+## Weekly Summary
+
+| Metric | Total | Avg/day |
+|--------|-------|---------|
+| recall count | | |
+| useful hit count | | |
+| useful hit rate | | |
+| practical wins | | |
+| setup success | | |
+| setup fail | | |
+
+## Decision
+
+- [ ] Continue
+- [ ] Improve
+- [ ] Pivot/Stop
+
+**Rationale:** (end of week)


### PR DESCRIPTION
## Summary
- `docs/KPI-WEEKLY-TEMPLATE.md` を追加 — 1 週間の adoption 計測テンプレート
- CHANGES.md に PR #28 のリリース判断を記録（v3.3.1 は切らない、次リリースに同梱）

## Deliverables checklist
- [x] PR #28 マージ確認
- [x] リリース判断: v3.3.1 なし、次リリースに同梱
- [x] KPI テンプレート: `docs/KPI-WEEKLY-TEMPLATE.md`
- [x] Day-1 サンプルエントリ記入済み

## Decision rubric
| Outcome | Criteria |
|---------|----------|
| Continue | useful hit rate >= 50% + practical wins >= 3 |
| Improve | 30-50% |
| Pivot/Stop | < 30% |

## Observation period
2026-03-17 → 2026-03-23

🤖 Generated with [Claude Code](https://claude.com/claude-code)